### PR TITLE
Update hsklogin

### DIFF
--- a/hsklogin
+++ b/hsklogin
@@ -4,7 +4,7 @@
 #            szymon@kapadia.pl                                      #
 #####################################################################
 
-ssh-add -e /usr/local/lib/libykcs11.dylib > /dev/null 2>&1
+ssh-add -e /usr/local/lib/libykcs11.dylib -t 57600 > /dev/null 2>&1
 if [[ $? == 0 ]]
   then
     echo -n "Existing keys removed..."


### PR DESCRIPTION
Set default time-out of credentials to 57600 seconds (16 hours) -- this should be enough for a normal working day but ensure that reauthentication with the pin is required at least once a day.