### PR TITLE
Add lifetime and other options

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ so that you don't have to type in the PIN for every git pull.
 
 ## Prerequirements
 
-Set up your yubikey for github SSH and test that it works correctly 
-(follow instructions at https://w3.ibm.com/#/support/article/hsk/github).
+Set up your yubikey for github SSH and test that it works correctly.
 
 
 ## Installing
@@ -44,8 +43,3 @@ The script performs the following steps:
   - lists the installed keys
 
 For more information, see `man ssh-add`.
-
-`hsklogin` was approved for use in the [#hsk-community])
-(https://ibm-security.slack.com/archives/C025SQRFM6H/p1666714770856989) 
-slack channel.
-

--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# hsk
+
+The `hsklogin` script uses the macOS ssh-agent with the yubikey, 
+so that you don't have to type in the PIN for every git pull.
+
+## Prerequirements
+
+Set up your yubikey for github SSH and test that it works correctly 
+(follow instructions at https://w3.ibm.com/#/support/article/hsk/github).
+
+
+## Installing
+
+```
+git clone https://github.com/mrszymon/hsk
+cd hsk
+sudo cp hsklogin /usr/local/bin
+chmod u+x /usr/local/bin/hsklogin
+```
+
+## Usage
+
+display installed keys:
+```
+hsklogin -l
+hsklogin -L
+```
+
+create keys using default life time:
+```
+hsklogin
+```
+
+create keys with an explicit life time (in seconds):
+```
+hsklogin -t 6000
+```
+
+delete installed keys:
+```
+hsklogin -e
+```
+
+
+## Further information
+
+You will be prompted for your yubikey PIN:
+- if keys are not installed
+- if installed keys have expired
+- following a reboot
+
+`hsklogin` can be executed multiple times. Keys are replaced on each execution.
+
+The script performs the following steps:
+- `ssh-add -e /usr/local/lib/libykcs11.dylib`
+  - removes any existing keys, with a specified duration (in seconds)
+- `ssh-add -s /usr/local/lib/libykcs11.dylib -t $life`
+  - prompts for your Yubikey PIN
+  - adds Yubikey keys
+- `ssh-add -l`
+  - lists the installed keys
+
+For more information, see `man ssh-add`.
+
+`hsklogin` was approved for use in the [#hsk-community])
+(https://ibm-security.slack.com/archives/C025SQRFM6H/p1666714770856989) 
+slack channel.
+

--- a/README.md
+++ b/README.md
@@ -20,25 +20,8 @@ chmod u+x /usr/local/bin/hsklogin
 
 ## Usage
 
-display installed keys:
 ```
-hsklogin -l
-hsklogin -L
-```
-
-create keys using default life time:
-```
-hsklogin
-```
-
-create keys with an explicit life time (in seconds):
-```
-hsklogin -t 6000
-```
-
-delete installed keys:
-```
-hsklogin -e
+hsklogin -h
 ```
 
 

--- a/hsklogin
+++ b/hsklogin
@@ -4,14 +4,34 @@
 #            szymon@kapadia.pl                                      #
 #####################################################################
 
-while getopts ":lL" option; do
+life=57600 # 16 hours
+
+usage() {
+   echo 'usage: hsklogin [-t life] [-elLh]
+     -t life: key life time in seconds
+     -e: delete keys
+     -l: display keys
+     -L: dislpay keys in detail
+     -h: print usage'
+}
+
+while getopts ":helLt:" option; do
    case $option in
+      h) # usage
+         usage
+         exit;;
+      e) # remove keys
+         ssh-add -e /usr/local/lib/libykcs11.dylib
+         exit;;
       l) # list public key hashes
          ssh-add -l
          exit;;
       L) # list full public keys
          ssh-add -L
          exit;;
+      t) # life: Set a maximum lifetime when adding identities to an agent.  The lifetime may be specified in seconds or in a time format specified in sshd_config(5).
+         life=$OPTARG
+         ;;
    esac
 done
 
@@ -23,8 +43,9 @@ if [[ $? == 0 ]]
     echo -n "No existing keys..."
 fi
 
+
 echo "Performing Login"
-ssh-add -s /usr/local/lib/libykcs11.dylib -t 57600 > /dev/null 2>&1
+ssh-add -s /usr/local/lib/libykcs11.dylib -t $life > /dev/null 2>&1
 if [[ $? == 0 ]] 
   then 
     echo "Keys added to agent"

--- a/hsklogin
+++ b/hsklogin
@@ -12,7 +12,16 @@ usage() {
      -e: delete keys
      -l: display keys
      -L: dislpay keys in detail
-     -h: print usage'
+     -h: print usage
+     
+     create keys using default life time:
+      hsklogin
+
+     create keys with an explicit life time (in seconds):
+      hsklogin -t 6000
+
+     delete installed keys:
+      hsklogin -e'
 }
 
 while getopts ":helLt:" option; do


### PR DESCRIPTION
Adds additional command line options
- `-t life`: to specify life time of keys
- `-e`: to delete keys without recreating
- `-h`: to print usage statement

Adds README file